### PR TITLE
Remove Policy Constructor and Improve Error Handling

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -134,8 +134,8 @@ pub fn get_secret_policy(sec: &String) -> Option<policy::Policy> {
     let val: Option<i32> = trnsx.exec_first(mqstr,(sec,)).ok()?;
 
     if val.is_none() {
-        error!(
-            "get_secret_policy::error cannot get policy id with secret {}",
+        info!(
+            "No policy has been set for secret with id: {}",
             &sec
         );
         return None;
@@ -203,9 +203,11 @@ pub fn get_secret(id: &String) -> Option<request::Key> {
     let mqstr = "SELECT secret FROM secrets WHERE secret_id = ?";
     let val: Option<String> = trnsx.exec_first(mqstr, (id,)).ok()?;
 
+    let payload = val?;
+
     Some(request::Key {
         id: id.to_string(),
-        payload: val.unwrap(),
+        payload,
     })
 }
 


### PR DESCRIPTION
There used to be a bug in the SEV library that required us to use our own function to generate a policy struct from an integer. This has been fixed in [this commit](https://github.com/enarx/sev/commit/acac2f06a1d80519be9383c26bc675e373595218) so we can get rid of our function. 

I made some minor updates to error handling. We need to be careful with which errors are propagated back to the user over gRPC and which are logged by the KBS. I updated `sev_tools.rs` so that the user is notified if they provide a malformed certificate chain. Previously this would have just been logged in the KBS, which isn't very helpful.

We do have a minor issue where a client can see via error message that a given key id is not known to the KBS even without having a valid launch measurement. I am going to fix this when I redo the request parsing logic.

@dubek 