### PR TITLE
Extensible request parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ anyhow = "1.0"
 uuid = { version = "0.8.2", features = ["serde", "v4"] }
 sev = { version = "0.2.0", features = ["openssl"] }
 codicon = "3.0"
-bincode = "1.0"
+bincode = "1.3.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 base64 = "0.13.0"

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -10,7 +10,7 @@ use std::fs;
 
 const DEFAULT_POLICY_PATH: &str = "default_policy.json";
 
-#[derive(Deserialize)]
+#[derive(Deserialize, PartialEq, Debug)]
 pub struct Policy {
     pub allowed_digests: Vec<String>,
     pub allowed_policies: Vec<u32>,


### PR DESCRIPTION
Revamp request parsing to be extensible, clearer, and have better error handling. Now you can add a new secret type by implementing the `SecretType` trait. I also added some unit tests. Note that there is no unit test for secret bundles yet because secret bundles aren't yet supported in the database code.

This fixes #6 and helps with #7.

Note that the policy db test is still failing. That is orthogonal to this PR and will hopefully be resolved soon.

@dubek 