### PR TITLE
Revert "Add license scan report and status"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,4 @@
 # Simple Key Broker Server 
-[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fconfidential-containers%2Fsimple-kbs.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fconfidential-containers%2Fsimple-kbs?ref=badge_shield)
-
 
 `simple-kbs` is a self-contained Key Broker Server for pre-attestation.
 The code is currently being developed in the `staging` branch.
-
-
-## License
-[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fconfidential-containers%2Fsimple-kbs.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fconfidential-containers%2Fsimple-kbs?ref=badge_large)


### PR DESCRIPTION
Reverts confidential-containers/simple-kbs#17

Reverting to simplify merge of staging into main. Also FOSSA doesn't really work for Rust so we will probably need a different longterm solution.