### PR TITLE
tools: Add run_local_tests.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ This KBS does not calculate the launch digest. The guest owner must calculate th
 This means that the guest firmware code does not need to be uploaded to the KBS and that SEV and SEV-ES launches follow an identical flow. 
 The downside is that the guest owner might have to generate more firmware digests ahead of time to account for variations in initrd or CPU count (for SEV-ES guests).
 
-
-
 Loosely based on [CCv0 SEV GOP script](https://github.com/confidential-containers-demo/scripts/tree/main/guest-owner-proxy).
+
+## Local development
+
+The [`tools/run_local_tests.sh`](tools/run_local_tests.sh) script creates a DB
+server container and runs the integration tests against it.

--- a/tools/run_local_tests.sh
+++ b/tools/run_local_tests.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -e
+
+echo "+ Running: cargo fmt"
+cargo fmt --all -- --check
+
+echo "+ Running: cargo clippy"
+cargo clippy -- -D warnings
+
+SIMPLE_KBS_DIR="$(dirname $0)/.."
+
+export KBS_DB_HOST=127.0.0.1
+export KBS_DB_USER=root
+export KBS_DB_PW=root
+export KBS_DB=simple_kbs
+
+echo "+ Starting DB server container..."
+docker run --detach --rm \
+           -p 3306:3306 \
+           --name kbs-db \
+           --env MARIADB_ROOT_PASSWORD=$KBS_DB_PW \
+           mariadb:latest
+
+sleep 5
+echo -n "+ Trying to connect to DB server..."
+while true ; do
+  echo -n '.'
+  if mysql --silent -u${KBS_DB_USER} -p${KBS_DB_PW} -h ${KBS_DB_HOST} -e "SELECT 1;" > /dev/null 2>&1 ; then
+    echo " Success!"
+    break
+  fi
+  sleep 1
+done
+
+echo "+ Creating database ${KBS_DB}"
+mysql -u${KBS_DB_USER} -p${KBS_DB_PW} -h ${KBS_DB_HOST} -e "CREATE DATABASE ${KBS_DB};"
+mysql -u${KBS_DB_USER} -p${KBS_DB_PW} -h ${KBS_DB_HOST} ${KBS_DB} < "${SIMPLE_KBS_DIR}/db.sql"
+
+echo "+ Running: cargo test"
+cargo test
+
+echo "+ Stopping DB server container..."
+docker stop kbs-db


### PR DESCRIPTION
The run_local_tests.sh script checks the source code with `cargo fmt`
and `cargo clippy`, starts a MariaDB server, sets up the simple_kbs DB
schema, and runs `cargo test` against that server.

This allows running simple-kbs tests locally (if you have docker
installed).

Signed-off-by: Dov Murik <dov.murik1@il.ibm.com>