### PR TITLE
client: Use sev-snp-measure to calculate expected launch digest

### DIFF
--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -1,0 +1,1 @@
+sev-snp-measure==0.0.3


### PR DESCRIPTION
The existing sev-snp-measure Python package can calculated the expected
measurement of SEV guests.  Replace the calc_launch_digest body in
client/LaunchVM.py to use it; this may allow measuring SEV-ES as well
with small modifications.

Signed-off-by: Dov Murik <dov.murik1@il.ibm.com>

----

To use this: `pip install sev-snp-measure`

Note: we should add other Python libraries used by the client to the `requirements.txt` file (separate PR).