### PR TITLE
Add Report secret type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ clap = "3.0.13"
 mysql = "22.0.0"
 log = "0.4.14"
 env_logger = "0.9.0"
+ring = "0.16.20"
+rand = "0.8.5"
+hex = "0.4.3"
 
 [build-dependencies]
 tonic-build = "0.5"

--- a/db.sql
+++ b/db.sql
@@ -108,6 +108,29 @@ CREATE TABLE `secrets` (
 -- Dumping data for table `secrets`
 --
 
+--
+-- Table structure for table `report_keys`
+--
+
+DROP TABLE IF EXISTS `report_keys`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `report_keypair` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `key_id` varchar(1024) DEFAULT NULL,
+  `keypair` varchar(1024) DEFAULT NULL,
+  `polid` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `key_id` (`key_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `report_keys`
+--
+
+
+
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
 /*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
 /*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;

--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -105,12 +105,12 @@ impl KeyBrokerService for KeyBroker {
         })?;
 
         // verify launch measurement
-        let session_verified = verify_measurement(connection, r.launch_measurement, session)
+        let session_verified = verify_measurement(&connection, r.launch_measurement, session)
             .map_err(|e| Status::internal(format!("Measurement Verification Failed: {}", e)))?;
 
         // get secret(s)
         let secret_payload = &secret_request
-            .payload()
+            .payload(&connection)
             .map_err(|e| Status::internal(format!("Cannot fulfill secret request: {}", e)))?;
 
         let (secret_header, secret_data) = package_secret(session_verified, secret_payload)

--- a/src/sev_tools.rs
+++ b/src/sev_tools.rs
@@ -35,11 +35,11 @@ pub fn generate_launch_bundle(
 }
 
 pub fn verify_measurement(
-    connection: db::Connection,
+    connection: &db::Connection,
     launch_measurement: String,
     session: Session<Initialized>,
 ) -> Result<Session<Verified>> {
-    let digest = base64::decode(connection.fw_digest)?;
+    let digest = base64::decode(&connection.fw_digest)?;
 
     let build = Build {
         version: Version {


### PR DESCRIPTION
The report secret type allows the KBS to provide a signed
copy of the launch information back to the KBC. This durable
report can be inspected at any point to confirm that the boot
was approved by the KBS (according to the policy set by the
report signing keys) and had certain parameters.

There are some future improvements planned here including supporting more types of signatures, adding a timestamp to the connection, and reformatting the signed connection into some more standard artifact. I think this is a good start.

@dubek 