### PR TITLE
Fixes #35 issues

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: --all-targets --all-features -- -D warnings -A clippy::derive_partial_eq_without_eq
 
   test:
     runs-on: ubuntu-latest

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -10,7 +10,7 @@ use std::fs;
 
 const DEFAULT_POLICY_PATH: &str = "default_policy.json";
 
-#[derive(Deserialize, PartialEq, Debug)]
+#[derive(Deserialize, PartialEq, Eq, Debug)]
 pub struct Policy {
     pub allowed_digests: Vec<String>,
     pub allowed_policies: Vec<u32>,

--- a/tools/run_local_tests.sh
+++ b/tools/run_local_tests.sh
@@ -6,7 +6,7 @@ echo "+ Running: cargo fmt"
 cargo fmt --all -- --check
 
 echo "+ Running: cargo clippy"
-cargo clippy -- -D warnings
+cargo clippy --all-targets --all-features -- -D warnings -A clippy::derive_partial_eq_without_eq
 
 SIMPLE_KBS_DIR="$(dirname $0)/.."
 
@@ -85,22 +85,3 @@ cargo test
 echo "+ Stopping kbs-db-postgres DB server container..."
 docker stop kbs-db-postgres
 
-echo "+ Updating exports for sqlite testing..."
-
-
-export KBS_DB_TYPE=sqlite
-export KBS_DB_HOST=localhost
-export KBS_DB_USER=${USER}
-export KBS_DB_PW=${USER}
-export KBS_DB=simple_kbs_test.db
-
-if [ -f ${KBS_DB} ]; then
-	rm -f ${KBS_DB}
-fi
-
-sqlite3 ${KBS_DB} < db-sqlite.sql 
-
-echo "+ Running: cargo test using local sqlite"
-cargo test
-
-rm -f ${KBS_DB}


### PR DESCRIPTION
I made updates requested by team to tighten up code by fixing errors when policy values are NULL for get_secret_policy and get_keyset_policy when the policy id is NULL.  I also removed unnecessary uses of unwrap and expect in db.rs and added a new env var KBS_DB_MAX_CONNS as suggest by James.

   This PR fixes issues highlighted in #35.

Signed-off-by: Derren Dunn <dunnderr@us.ibm.com>