### PR TITLE
Basic support for resource secret type

### DIFF
--- a/db-mysql.sql
+++ b/db-mysql.sql
@@ -130,6 +130,28 @@ CREATE TABLE `report_keypair` (
 -- Dumping data for table `report_keypair`
 --
 
+--
+-- Table structure for table `resources`
+--
+
+DROP TABLE IF EXISTS `resources`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `resources` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `resource_id` varchar(1024) DEFAULT NULL,
+  `resource_type` varchar(1024) DEFAULT NULL,
+  `resource_path` varchar(1024) DEFAULT NULL,
+  `polid` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `resource_id` (`resource_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `resources`
+--
+
 
 
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;

--- a/db-postgres.sql
+++ b/db-postgres.sql
@@ -130,6 +130,28 @@ CREATE TABLE report_keypair (
 -- Dumping data for table report_keypair
 --
 
+--
+-- Table structure for table resources
+--
+
+-- DROP TABLE IF EXISTS resources;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE resources (
+  id SERIAL NOT NULL,
+  resource_id varchar(1024) DEFAULT NULL,
+  resource_type varchar(1024) DEFAULT NULL,
+  resource_path varchar(1024) DEFAULT NULL,
+  polid BIGINT DEFAULT NULL,
+  PRIMARY KEY (id),
+  UNIQUE(resource_id)
+);
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table resources 
+--
+
 
 
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;

--- a/db-sqlite.sql
+++ b/db-sqlite.sql
@@ -46,5 +46,14 @@ CREATE TABLE `report_keypair` (
 `polid` int(11) DEFAULT NULL,
 UNIQUE(`key_id`)
 );
+CREATE TABLE `resources` (
+`id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+`resource_id` varchar(1024) DEFAULT NULL,
+`resource_type` varchar(1024) DEFAULT NULL,
+`resource_path` varchar(1024) DEFAULT NULL,
+`polid` int(11) DEFAULT NULL,
+UNIQUE(`resource_id`)
+);
+
 DELETE FROM sqlite_sequence;
 COMMIT;


### PR DESCRIPTION
Support for getting resources from the KBS. This will be used for signature verification among other things. 

For now there is a simple database table that keeps track of the different resources and the policies associated with them. At the moment we are only supporting one resource per `resource_type` and the `resource_id` is unused. This looks a bit weird and will be updated after the first release when we add an additional parameters field to the request api. Until then I think this is the best way.

@dubek 