### PR TITLE
[WIP] Add Dockerfiles and docker-compose configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+/Dockerfile*
+/docker-compose.yml
+/.git
+/target

--- a/Dockerfile.kbs-db
+++ b/Dockerfile.kbs-db
@@ -1,0 +1,4 @@
+FROM mariadb:latest
+
+COPY db-mysql.sql /docker-entrypoint-initdb.d/10-db-mysql.sql
+COPY db/initial-data.sql /docker-entrypoint-initdb.d/20-initial-data.sql

--- a/Dockerfile.simple-kbs
+++ b/Dockerfile.simple-kbs
@@ -1,0 +1,18 @@
+FROM rust:1 AS builder
+RUN rustup component add rustfmt
+WORKDIR /usr/src/simple-kbs
+COPY . .
+RUN cargo build --release
+
+# -----------------------------------------------------------------------------
+
+# The rust:1 image is built using Debian bullseye, so use the same distro for
+# the final simple-kbs image
+FROM debian:bullseye
+
+WORKDIR /usr/local/bin
+COPY --from=builder /usr/src/simple-kbs/target/release/simple-kbs ./
+COPY default_policy.json ./
+
+EXPOSE 44444
+CMD ["simple-kbs", "--grpc_sock=0.0.0.0:44444"]

--- a/db/initial-data.sql
+++ b/db/initial-data.sql
@@ -1,0 +1,9 @@
+--
+-- Below is the encryption key of the encrypted docker image:
+--
+--     quay.io/kata-containers/encrypted-image-tests:encrypted
+--
+-- which is used in CI testing of Confidential Containers and simple-kbs
+--
+INSERT INTO secrets VALUES (10, 'key_id1', 'RcHGava52DPvj1uoIk/NVDYlwxi0A6yyIZ8ilhEX3X4=', NULL);
+INSERT INTO keysets VALUES (10, 'KEYSET-1', '["key_id1"]', NULL);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.1'
+
+services:
+  server:
+    build:
+      context: .
+      dockerfile: Dockerfile.simple-kbs
+    restart: always
+    environment:
+      KBS_DB_TYPE: mysql
+      KBS_DB_HOST: db
+      KBS_DB_USER: kbsuser
+      KBS_DB_PW: kbspassword
+      KBS_DB: simple_kbs
+      RUST_LOG: debug
+    ports:
+      - "44444:44444"
+    depends_on:
+      - db
+
+  db:
+    build:
+      context: .
+      dockerfile: Dockerfile.kbs-db
+    restart: always
+    environment:
+      MARIADB_ROOT_PASSWORD: unused
+      MARIADB_DATABASE: simple_kbs
+      MARIADB_USER: kbsuser
+      MARIADB_PASSWORD: kbspassword


### PR DESCRIPTION
Running `docker compose build` and `docker compose up` will start a simple-kbs container with the backend MariaDB container.  The DB is pre-populated with a simple configuration used during CI tests of Confidential Containers with simple-kbs.

Signed-off-by: Dov Murik <dov.murik1@il.ibm.com>

----

cc: @fitzthum @dunnderr 