### PR TITLE
Bump version number to 0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-kbs"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Cut a release. I'll let this sit for a few days in case we find a problem.

Signed-off-by: Tobin Feldman-Fitzthum <tobin@ibm.com>