### PR TITLE
main: Automatically take version from Cargo.toml

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,11 +15,13 @@ pub mod policy;
 pub mod request;
 pub mod sev_tools;
 
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 #[tokio::main]
 async fn main() -> Result<()> {
     env_logger::init();
     let args = Command::new("simple-kbs")
-        .version("0.0.1")
+        .version(VERSION)
         .arg(
             Arg::new("socket addr")
                 .long("grpc_sock")


### PR DESCRIPTION
Remove the hard-coded version string from main.rs.

Signed-off-by: Dov Murik <dov.murik1@il.ibm.com>

---

Test:

```
$ cargo build
$ target/debug/simple-kbs --version
simple-kbs 0.1.0
```