### PR TITLE
Dunnderr missing keys logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1470,7 +1470,7 @@ dependencies = [
 
 [[package]]
 name = "simple-kbs"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/src/db.rs
+++ b/src/db.rs
@@ -7,6 +7,7 @@ use crate::policy;
 use crate::request;
 
 use anyhow::*;
+use log::*;
 use rand::Rng;
 use std::env;
 use std::result::Result::Ok;
@@ -314,12 +315,33 @@ impl KbsDb {
         let query_str = "SELECT kskeys FROM keysets WHERE keysetid = ?";
         let new_query_str = self.replace_binds(query_str);
 
-        let keyset_row = sqlx::query(&new_query_str)
+        // Need to check 2 cases: 1) no keyset keys are returned from the query; 2) keysets are
+        // returned but cannot be deserialized into JSON by serde_json::from_str().
+        let keyset_row = match sqlx::query(&new_query_str)
             .bind(keysetid)
             .fetch_one(&self.dbpool)
-            .await?;
-        let rks: Vec<String> = serde_json::from_str(&keyset_row.try_get::<String, _>(0)?)?;
-        Ok(rks)
+            .await
+        {
+            Ok(ksr) => ksr,
+            Err(e) => {
+                warn!(
+                    "db::get_keyset_ids did not return keyset ids for id {}, query error {}",
+                    keysetid, e
+                );
+                return Ok(Vec::<String>::new());
+            }
+        };
+
+        match serde_json::from_str(&keyset_row.try_get::<String, _>(0)?) {
+            Ok(rkv) => Ok(rkv),
+            Err(e) => {
+                warn!(
+                    "db::get_keyset_ids did return a row for keyset id {}, but was not able to create JSON using serde_json::from_str() with error {}",
+                    keysetid, e
+                );
+                Ok(Vec::<String>::new())
+            }
+        }
     }
 
     pub async fn get_secret(&self, secret_id: &str) -> Result<request::Key> {
@@ -371,7 +393,7 @@ impl KbsDb {
         keypair: &[u8],
         policy_id: Option<u64>,
     ) -> Result<()> {
-        let keypair_b64 = base64::encode(&keypair);
+        let keypair_b64 = base64::encode(keypair);
         let query_str = "INSERT INTO report_keypair (key_id, keypair, polid ) VALUES(?, ?, ?)";
         let new_query_str = self.replace_binds(query_str);
         sqlx::query(&new_query_str)
@@ -624,7 +646,6 @@ mod tests {
         Ok(())
     }
 
-    //#[test]
     #[tokio::test]
     async fn test_insert_keyset() -> anyhow::Result<()> {
         let db = KbsDb::new().await?;
@@ -657,6 +678,15 @@ mod tests {
 
         db.delete_keyset(&ksetid).await?;
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_get_keyset_no_entry() -> anyhow::Result<()> {
+        let db = KbsDb::new().await?;
+        let bad_ksetid = Uuid::new_v4().as_hyphenated().to_string();
+        let empty_vec = db.get_keyset_ids(&bad_ksetid).await?;
+        assert_eq!(empty_vec.len(), 0);
         Ok(())
     }
 

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -21,7 +21,7 @@ pub struct Policy {
 
 impl Policy {
     pub fn tenant_default() -> Result<Policy> {
-        let policy_string = fs::read_to_string(&DEFAULT_POLICY_PATH).map_err(|e| {
+        let policy_string = fs::read_to_string(DEFAULT_POLICY_PATH).map_err(|e| {
             anyhow!(
                 "Default tenant configuration expected at {}. Error: {}",
                 &DEFAULT_POLICY_PATH,


### PR DESCRIPTION
This pull request addresses issue #33 to provide better error handing for missing keysets.  A warning will be logged when no keyset ids are returned from db::get_keyset_ids.  