### PR TITLE
Fix clippy warnings about needless borrows

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -414,7 +414,7 @@ impl KbsDb {
             .fetch_one(&self.dbpool)
             .await?;
         let kp = key_row.try_get::<String, _>(0)?;
-        let kp_bytes = base64::decode(&kp)?;
+        let kp_bytes = base64::decode(kp)?;
         Ok(kp_bytes)
     }
 

--- a/src/sev_tools.rs
+++ b/src/sev_tools.rs
@@ -16,7 +16,7 @@ pub fn generate_launch_bundle(
 ) -> Result<(String, String, Session<Initialized>)> {
     let session = Session::try_from(Policy::from(policy)).unwrap();
 
-    let mut bin_chain = std::io::Cursor::new(base64::decode(&cert_chain)?);
+    let mut bin_chain = std::io::Cursor::new(base64::decode(cert_chain)?);
     let chain = sev::certs::Chain::decode(&mut bin_chain, ())
         .map_err(|e| anyhow!("Cert Chain not formatted correctly: {}", e))?;
 
@@ -28,7 +28,7 @@ pub fn generate_launch_bundle(
     let mut binary_godh = std::io::Cursor::new(Vec::new());
     start.cert.encode(&mut binary_godh, ())?;
 
-    let godh = base64::encode(&binary_godh.into_inner());
+    let godh = base64::encode(binary_godh.into_inner());
     let launch_blob = base64::encode(bincode::serialize(&start.session).unwrap());
 
     Ok((godh, launch_blob, session))
@@ -49,7 +49,7 @@ pub fn verify_measurement(
         build: connection.fw_build_id as u8,
     };
 
-    let mut bin_measure = std::io::Cursor::new(base64::decode(&launch_measurement)?);
+    let mut bin_measure = std::io::Cursor::new(base64::decode(launch_measurement)?);
     let measure = sev::launch::sev::Measurement::decode(&mut bin_measure, ()).unwrap();
 
     session


### PR DESCRIPTION
Clippy failed with several instances of:

    error: the borrowed expression implements the required traits

Fix the errors by removing the address-of (&) operator.

Signed-off-by: Dov Murik <dov.murik1@il.ibm.com>