### PR TITLE
Copy image signing resources into docker filesystem

### DIFF
--- a/Dockerfile.simple-kbs
+++ b/Dockerfile.simple-kbs
@@ -13,6 +13,7 @@ FROM debian:bullseye
 WORKDIR /usr/local/bin
 COPY --from=builder /usr/src/simple-kbs/target/release/simple-kbs ./
 COPY default_policy.json ./
+COPY resources resources/
 
 EXPOSE 44444
 CMD ["simple-kbs", "--grpc_sock=0.0.0.0:44444"]


### PR DESCRIPTION
Resources such as the policy.json and cosign.pub used to verify a signed image need to be copied into the docker environment to get used.

Signed-off-by: Alex Carter <Alex.Carter@ibm.com>