### PR TITLE
docker: update rust image used to specific bullseye version

### DIFF
--- a/Dockerfile.simple-kbs
+++ b/Dockerfile.simple-kbs
@@ -1,4 +1,4 @@
-FROM rust:1 AS builder
+FROM rust:1.72.0-bullseye AS builder
 RUN rustup component add rustfmt
 WORKDIR /usr/src/simple-kbs
 COPY . .


### PR DESCRIPTION
'rust:1' was recently updated and doesn't support openssl v3.
The simple-kbs runs without crashing using the 'rust:1.72.0-bullseye' tag.

Fixes: #61